### PR TITLE
task/9 getFieldValue now works for addlProps

### DIFF
--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/impl3/PathImpl.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/impl3/PathImpl.java
@@ -1,11 +1,10 @@
 package com.reprezen.swaggerparser.impl3;
 
-import java.util.Collection;
-import java.util.Map;
-
-import javax.annotation.Generated;
-
 import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.swaggerparser.impl3.OperationImpl;
+import com.reprezen.swaggerparser.impl3.ParameterImpl;
+import com.reprezen.swaggerparser.impl3.ServerImpl;
+import com.reprezen.swaggerparser.impl3.SwaggerObjectImpl;
 import com.reprezen.swaggerparser.jsonoverlay.JsonOverlay;
 import com.reprezen.swaggerparser.jsonoverlay.JsonOverlayFactory;
 import com.reprezen.swaggerparser.jsonoverlay.coll.ListOverlay;
@@ -17,6 +16,9 @@ import com.reprezen.swaggerparser.model3.Operation;
 import com.reprezen.swaggerparser.model3.Parameter;
 import com.reprezen.swaggerparser.model3.Path;
 import com.reprezen.swaggerparser.model3.Server;
+import java.util.Collection;
+import java.util.Map;
+import javax.annotation.Generated;
 
 public class PathImpl extends SwaggerObjectImpl implements Path {
 
@@ -114,25 +116,19 @@ public class PathImpl extends SwaggerObjectImpl implements Path {
     private StringOverlay summary = registerField("summary", "summary", null, new StringOverlay("summary", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null,
-            new StringOverlay("description", this));
+    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<OperationImpl> operations = registerField("", "operations",
-            "get|put|post|delete|options|head|patch|trace", new MapOverlay<OperationImpl>("", this,
-                    OperationImpl.factory, "get|put|post|delete|options|head|patch|trace"));
+    private MapOverlay<OperationImpl> operations = registerField("", "operations", "get|put|post|delete|options|head|patch|trace", new MapOverlay<OperationImpl>("", this, OperationImpl.factory, "get|put|post|delete|options|head|patch|trace"));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<ServerImpl> servers = registerField("servers", "servers", null,
-            new ListOverlay<ServerImpl>("servers", this, ServerImpl.factory));
+    private ListOverlay<ServerImpl> servers = registerField("servers", "servers", null, new ListOverlay<ServerImpl>("servers", this, ServerImpl.factory));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<ParameterImpl> parameters = registerField("parameters", "parameters", null,
-            new ListOverlay<ParameterImpl>("parameters", this, ParameterImpl.factory));
+    private ListOverlay<ParameterImpl> parameters = registerField("parameters", "parameters", null, new ListOverlay<ParameterImpl>("parameters", this, ParameterImpl.factory));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object, AnyObjectOverlay> extensions = registerField("", "extensions", "x-.*",
-            new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.*"));
+    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.*", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.*"));
 
     // Summary
     @Override
@@ -183,8 +179,8 @@ public class PathImpl extends SwaggerObjectImpl implements Path {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setOperations(Map<String, ? extends Operation> operations) {
         @SuppressWarnings("unchecked")
-        Map<String, OperationImpl> implOperations = (Map<String, OperationImpl>) operations;
-        this.operations.set(implOperations);
+            Map<String,OperationImpl> implOperations = (Map<String, OperationImpl>) operations;
+            this.operations.set(implOperations);
     }
 
     @Override
@@ -216,8 +212,8 @@ public class PathImpl extends SwaggerObjectImpl implements Path {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setServers(Collection<? extends Server> servers) {
         @SuppressWarnings("unchecked")
-        Collection<ServerImpl> implServers = (Collection<ServerImpl>) servers;
-        this.servers.set(implServers);
+            Collection<ServerImpl> implServers = (Collection<ServerImpl>) servers;
+            this.servers.set(implServers);
     }
 
     @Override
@@ -255,8 +251,8 @@ public class PathImpl extends SwaggerObjectImpl implements Path {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setParameters(Collection<? extends Parameter> parameters) {
         @SuppressWarnings("unchecked")
-        Collection<ParameterImpl> implParameters = (Collection<ParameterImpl>) parameters;
-        this.parameters.set(implParameters);
+            Collection<ParameterImpl> implParameters = (Collection<ParameterImpl>) parameters;
+            this.parameters.set(implParameters);
     }
 
     @Override
@@ -316,10 +312,10 @@ public class PathImpl extends SwaggerObjectImpl implements Path {
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public static JsonOverlayFactory<PathImpl> factory = new JsonOverlayFactory<PathImpl>() {
-        @Override
-        public PathImpl create(String key, JsonNode json, JsonOverlay<?> parent) {
-            return isEmptyRecursive(parent, PathImpl.class) ? null : new PathImpl(key, json, parent);
-        }
-    };
+    @Override
+    public PathImpl create(String key, JsonNode json, JsonOverlay<?> parent) {
+        return isEmptyRecursive(parent, PathImpl.class) ? null : new PathImpl(key, json, parent);
+    }
+};
 
 }

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/impl3/SchemaImpl.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/impl3/SchemaImpl.java
@@ -1,10 +1,12 @@
 package com.reprezen.swaggerparser.impl3;
 
+import java.util.Collection;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.swaggerparser.impl3.ExternalDocsImpl;
-import com.reprezen.swaggerparser.impl3.SchemaImpl;
-import com.reprezen.swaggerparser.impl3.SwaggerObjectImpl;
-import com.reprezen.swaggerparser.impl3.XmlImpl;
+import com.google.common.base.Optional;
 import com.reprezen.swaggerparser.jsonoverlay.JsonOverlay;
 import com.reprezen.swaggerparser.jsonoverlay.JsonOverlayFactory;
 import com.reprezen.swaggerparser.jsonoverlay.coll.ListOverlay;
@@ -19,11 +21,23 @@ import com.reprezen.swaggerparser.jsonoverlay.std.StringOverlay;
 import com.reprezen.swaggerparser.model3.ExternalDocs;
 import com.reprezen.swaggerparser.model3.Schema;
 import com.reprezen.swaggerparser.model3.Xml;
-import java.util.Collection;
-import java.util.Map;
-import javax.annotation.Generated;
 
 public class SchemaImpl extends SwaggerObjectImpl implements Schema {
+
+    @Override
+    public Optional<JsonOverlay<?>> getFieldValue(String path) throws IllegalArgumentException, IllegalAccessException {
+        if (path.equals("additionalProperties")) {
+            if (additionalPropertiesSchema != null && !additionalPropertiesSchema.isMissing()) {
+                return Optional.<JsonOverlay<?>> of(additionalPropertiesSchema);
+            } else if (additionalProperties != null && !additionalProperties.isMissing()) {
+                return Optional.<JsonOverlay<?>> of(additionalProperties);
+            } else {
+                return Optional.absent();
+            }
+        } else {
+            return super.getFieldValue(path);
+        }
+    }
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public SchemaImpl(String key, JsonNode json, JsonOverlay<?> parent) {
@@ -39,25 +53,30 @@ public class SchemaImpl extends SwaggerObjectImpl implements Schema {
     private StringOverlay title = registerField("title", "title", null, new StringOverlay("title", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private NumberOverlay multipleOf = registerField("multipleOf", "multipleOf", null, new NumberOverlay("multipleOf", this));
+    private NumberOverlay multipleOf = registerField("multipleOf", "multipleOf", null,
+            new NumberOverlay("multipleOf", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     private NumberOverlay maximum = registerField("maximum", "maximum", null, new NumberOverlay("maximum", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay exclusiveMaximum = registerField("exclusiveMaximum", "exclusiveMaximum", null, new BooleanOverlay("exclusiveMaximum", this));
+    private BooleanOverlay exclusiveMaximum = registerField("exclusiveMaximum", "exclusiveMaximum", null,
+            new BooleanOverlay("exclusiveMaximum", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     private NumberOverlay minimum = registerField("minimum", "minimum", null, new NumberOverlay("minimum", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay exclusiveMinimum = registerField("exclusiveMinimum", "exclusiveMinimum", null, new BooleanOverlay("exclusiveMinimum", this));
+    private BooleanOverlay exclusiveMinimum = registerField("exclusiveMinimum", "exclusiveMinimum", null,
+            new BooleanOverlay("exclusiveMinimum", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private IntegerOverlay maxLength = registerField("maxLength", "maxLength", null, new IntegerOverlay("maxLength", this));
+    private IntegerOverlay maxLength = registerField("maxLength", "maxLength", null,
+            new IntegerOverlay("maxLength", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private IntegerOverlay minLength = registerField("minLength", "minLength", null, new IntegerOverlay("minLength", this));
+    private IntegerOverlay minLength = registerField("minLength", "minLength", null,
+            new IntegerOverlay("minLength", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     private StringOverlay pattern = registerField("pattern", "pattern", null, new StringOverlay("pattern", this));
@@ -69,82 +88,105 @@ public class SchemaImpl extends SwaggerObjectImpl implements Schema {
     private IntegerOverlay minItems = registerField("minItems", "minItems", null, new IntegerOverlay("minItems", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay uniqueItems = registerField("uniqueItems", "uniqueItems", null, new BooleanOverlay("uniqueItems", this));
+    private BooleanOverlay uniqueItems = registerField("uniqueItems", "uniqueItems", null,
+            new BooleanOverlay("uniqueItems", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private IntegerOverlay maxProperties = registerField("maxProperties", "maxProperties", null, new IntegerOverlay("maxProperties", this));
+    private IntegerOverlay maxProperties = registerField("maxProperties", "maxProperties", null,
+            new IntegerOverlay("maxProperties", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private IntegerOverlay minProperties = registerField("minProperties", "minProperties", null, new IntegerOverlay("minProperties", this));
+    private IntegerOverlay minProperties = registerField("minProperties", "minProperties", null,
+            new IntegerOverlay("minProperties", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ValListOverlay<String, StringOverlay> requiredFields = registerField("required", "requiredFields", null, new ValListOverlay<String, StringOverlay>("required", this, StringOverlay.factory));;
+    private ValListOverlay<String, StringOverlay> requiredFields = registerField("required", "requiredFields", null,
+            new ValListOverlay<String, StringOverlay>("required", this, StringOverlay.factory));;
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ValListOverlay<Object, AnyObjectOverlay> enums = registerField("enum", "enums", null, new ValListOverlay<Object, AnyObjectOverlay>("enum", this, AnyObjectOverlay.factory));;
+    private ValListOverlay<Object, AnyObjectOverlay> enums = registerField("enum", "enums", null,
+            new ValListOverlay<Object, AnyObjectOverlay>("enum", this, AnyObjectOverlay.factory));;
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     private StringOverlay type = registerField("type", "type", null, new StringOverlay("type", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<SchemaImpl> allOfSchemass = registerField("allOf", "allOfSchemass", null, new ListOverlay<SchemaImpl>("allOf", this, SchemaImpl.factory));
+    private ListOverlay<SchemaImpl> allOfSchemass = registerField("allOf", "allOfSchemass", null,
+            new ListOverlay<SchemaImpl>("allOf", this, SchemaImpl.factory));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<SchemaImpl> oneOfSchemass = registerField("oneOf", "oneOfSchemass", null, new ListOverlay<SchemaImpl>("oneOf", this, SchemaImpl.factory));
+    private ListOverlay<SchemaImpl> oneOfSchemass = registerField("oneOf", "oneOfSchemass", null,
+            new ListOverlay<SchemaImpl>("oneOf", this, SchemaImpl.factory));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<SchemaImpl> anyOfSchemass = registerField("anyOf", "anyOfSchemass", null, new ListOverlay<SchemaImpl>("anyOf", this, SchemaImpl.factory));
+    private ListOverlay<SchemaImpl> anyOfSchemass = registerField("anyOf", "anyOfSchemass", null,
+            new ListOverlay<SchemaImpl>("anyOf", this, SchemaImpl.factory));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     private SchemaImpl notSchema = registerField("not", "notSchema", null, SchemaImpl.factory.create("not", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private SchemaImpl itemsSchema = registerField("items", "itemsSchema", null, SchemaImpl.factory.create("items", this));
+    private SchemaImpl itemsSchema = registerField("items", "itemsSchema", null,
+            SchemaImpl.factory.create("items", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<SchemaImpl> properties = registerField("properties", "properties", null, new MapOverlay<SchemaImpl>("properties", this, SchemaImpl.factory, null));
+    private MapOverlay<SchemaImpl> properties = registerField("properties", "properties", null,
+            new MapOverlay<SchemaImpl>("properties", this, SchemaImpl.factory, null));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay additionalProperties = registerField("additionalProperties", "additionalProperties", null, new BooleanOverlay("additionalProperties", this));
+    private SchemaImpl additionalPropertiesSchema = registerField("additionalProperties", "additionalPropertiesSchema",
+            null, SchemaImpl.factory.create("additionalProperties", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private BooleanOverlay additionalProperties = registerField("additionalProperties", "additionalProperties", null,
+            new BooleanOverlay("additionalProperties", this));
+
+    @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
+    private StringOverlay description = registerField("description", "description", null,
+            new StringOverlay("description", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     private StringOverlay format = registerField("format", "format", null, new StringOverlay("format", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private AnyObjectOverlay defaultValue = registerField("default", "defaultValue", null, new AnyObjectOverlay("default", this));
+    private AnyObjectOverlay defaultValue = registerField("default", "defaultValue", null,
+            new AnyObjectOverlay("default", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     private BooleanOverlay nullable = registerField("nullable", "nullable", null, new BooleanOverlay("nullable", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay discriminator = registerField("discriminator", "discriminator", null, new StringOverlay("discriminator", this));
+    private StringOverlay discriminator = registerField("discriminator", "discriminator", null,
+            new StringOverlay("discriminator", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     private BooleanOverlay readOnly = registerField("readOnly", "readOnly", null, new BooleanOverlay("readOnly", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay writeOnly = registerField("writeOnly", "writeOnly", null, new BooleanOverlay("writeOnly", this));
+    private BooleanOverlay writeOnly = registerField("writeOnly", "writeOnly", null,
+            new BooleanOverlay("writeOnly", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     private XmlImpl xml = registerField("xml", "xml", null, XmlImpl.factory.create("xml", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ExternalDocsImpl externalDocs = registerField("externalDocs", "externalDocs", null, ExternalDocsImpl.factory.create("externalDocs", this));
+    private ExternalDocsImpl externalDocs = registerField("externalDocs", "externalDocs", null,
+            ExternalDocsImpl.factory.create("externalDocs", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ValListOverlay<Object, AnyObjectOverlay> examples = registerField("examples", "examples", null, new ValListOverlay<Object, AnyObjectOverlay>("examples", this, AnyObjectOverlay.factory));;
+    private ValListOverlay<Object, AnyObjectOverlay> examples = registerField("examples", "examples", null,
+            new ValListOverlay<Object, AnyObjectOverlay>("examples", this, AnyObjectOverlay.factory));;
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     private AnyObjectOverlay example = registerField("example", "example", null, new AnyObjectOverlay("example", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay deprecated = registerField("deprecated", "deprecated", null, new BooleanOverlay("deprecated", this));
+    private BooleanOverlay deprecated = registerField("deprecated", "deprecated", null,
+            new BooleanOverlay("deprecated", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.*", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.*"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = registerField("", "extensions", "x-.*",
+            new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.*"));
 
     // Title
     @Override
@@ -362,7 +404,7 @@ public class SchemaImpl extends SwaggerObjectImpl implements Schema {
     @Override
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setRequiredFields(Collection<String> requiredFields) {
-        this.requiredFields.set((Collection<String>) requiredFields);
+        this.requiredFields.set(requiredFields);
     }
 
     @Override
@@ -399,7 +441,7 @@ public class SchemaImpl extends SwaggerObjectImpl implements Schema {
     @Override
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setEnums(Collection<Object> enums) {
-        this.enums.set((Collection<Object>) enums);
+        this.enums.set(enums);
     }
 
     @Override
@@ -450,8 +492,8 @@ public class SchemaImpl extends SwaggerObjectImpl implements Schema {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setAllOfSchemass(Collection<? extends Schema> allOfSchemass) {
         @SuppressWarnings("unchecked")
-            Collection<SchemaImpl> implAllOfSchemass = (Collection<SchemaImpl>) allOfSchemass;
-            this.allOfSchemass.set(implAllOfSchemass);
+        Collection<SchemaImpl> implAllOfSchemass = (Collection<SchemaImpl>) allOfSchemass;
+        this.allOfSchemass.set(implAllOfSchemass);
     }
 
     @Override
@@ -489,8 +531,8 @@ public class SchemaImpl extends SwaggerObjectImpl implements Schema {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setOneOfSchemass(Collection<? extends Schema> oneOfSchemass) {
         @SuppressWarnings("unchecked")
-            Collection<SchemaImpl> implOneOfSchemass = (Collection<SchemaImpl>) oneOfSchemass;
-            this.oneOfSchemass.set(implOneOfSchemass);
+        Collection<SchemaImpl> implOneOfSchemass = (Collection<SchemaImpl>) oneOfSchemass;
+        this.oneOfSchemass.set(implOneOfSchemass);
     }
 
     @Override
@@ -528,8 +570,8 @@ public class SchemaImpl extends SwaggerObjectImpl implements Schema {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setAnyOfSchemass(Collection<? extends Schema> anyOfSchemass) {
         @SuppressWarnings("unchecked")
-            Collection<SchemaImpl> implAnyOfSchemass = (Collection<SchemaImpl>) anyOfSchemass;
-            this.anyOfSchemass.set(implAnyOfSchemass);
+        Collection<SchemaImpl> implAnyOfSchemass = (Collection<SchemaImpl>) anyOfSchemass;
+        this.anyOfSchemass.set(implAnyOfSchemass);
     }
 
     @Override
@@ -599,8 +641,8 @@ public class SchemaImpl extends SwaggerObjectImpl implements Schema {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setProperties(Map<String, ? extends Schema> properties) {
         @SuppressWarnings("unchecked")
-            Map<String,SchemaImpl> implProperties = (Map<String, SchemaImpl>) properties;
-            this.properties.set(implProperties);
+        Map<String, SchemaImpl> implProperties = (Map<String, SchemaImpl>) properties;
+        this.properties.set(implProperties);
     }
 
     @Override
@@ -613,6 +655,19 @@ public class SchemaImpl extends SwaggerObjectImpl implements Schema {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void removeProperty(String name) {
         properties.remove(name);
+    }
+
+    // AdditionalPropertiesSchema
+    @Override
+    @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
+    public Schema getAdditionalPropertiesSchema() {
+        return additionalPropertiesSchema;
+    }
+
+    @Override
+    @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
+    public void setAdditionalPropertiesSchema(Schema additionalPropertiesSchema) {
+        this.additionalPropertiesSchema.set((SchemaImpl) additionalPropertiesSchema);
     }
 
     // AdditionalProperties
@@ -785,7 +840,7 @@ public class SchemaImpl extends SwaggerObjectImpl implements Schema {
     @Override
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setExamples(Collection<Object> examples) {
-        this.examples.set((Collection<Object>) examples);
+        this.examples.set(examples);
     }
 
     @Override
@@ -877,10 +932,10 @@ public class SchemaImpl extends SwaggerObjectImpl implements Schema {
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public static JsonOverlayFactory<SchemaImpl> factory = new JsonOverlayFactory<SchemaImpl>() {
-    @Override
-    public SchemaImpl create(String key, JsonNode json, JsonOverlay<?> parent) {
-        return isEmptyRecursive(parent, SchemaImpl.class) ? null : new SchemaImpl(key, json, parent);
-    }
-};
+        @Override
+        public SchemaImpl create(String key, JsonNode json, JsonOverlay<?> parent) {
+            return isEmptyRecursive(parent, SchemaImpl.class) ? null : new SchemaImpl(key, json, parent);
+        }
+    };
 
 }

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/impl3/Swagger3Impl.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/impl3/Swagger3Impl.java
@@ -1,11 +1,21 @@
 package com.reprezen.swaggerparser.impl3;
 
-import java.util.Collection;
-import java.util.Map;
-
-import javax.annotation.Generated;
-
 import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.swaggerparser.impl3.CallbackImpl;
+import com.reprezen.swaggerparser.impl3.ExternalDocsImpl;
+import com.reprezen.swaggerparser.impl3.HeaderImpl;
+import com.reprezen.swaggerparser.impl3.InfoImpl;
+import com.reprezen.swaggerparser.impl3.LinkImpl;
+import com.reprezen.swaggerparser.impl3.ParameterImpl;
+import com.reprezen.swaggerparser.impl3.PathImpl;
+import com.reprezen.swaggerparser.impl3.RequestBodyImpl;
+import com.reprezen.swaggerparser.impl3.ResponseImpl;
+import com.reprezen.swaggerparser.impl3.SchemaImpl;
+import com.reprezen.swaggerparser.impl3.SecurityRequirementImpl;
+import com.reprezen.swaggerparser.impl3.SecuritySchemeImpl;
+import com.reprezen.swaggerparser.impl3.ServerImpl;
+import com.reprezen.swaggerparser.impl3.SwaggerObjectImpl;
+import com.reprezen.swaggerparser.impl3.TagImpl;
 import com.reprezen.swaggerparser.jsonoverlay.JsonOverlay;
 import com.reprezen.swaggerparser.jsonoverlay.JsonOverlayFactory;
 import com.reprezen.swaggerparser.jsonoverlay.coll.ListOverlay;
@@ -31,6 +41,9 @@ import com.reprezen.swaggerparser.model3.Tag;
 import com.reprezen.swaggerparser.val.ValidationResults;
 import com.reprezen.swaggerparser.val.ValidationResults.Severity;
 import com.reprezen.swaggerparser.val3.Swagger3Validator;
+import java.util.Collection;
+import java.util.Map;
+import javax.annotation.Generated;
 
 public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
 
@@ -80,78 +93,55 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
     private InfoImpl info = registerField("info", "info", null, InfoImpl.factory.create("info", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<ServerImpl> servers = registerField("servers", "servers", null,
-            new ListOverlay<ServerImpl>("servers", this, ServerImpl.factory));
+    private ListOverlay<ServerImpl> servers = registerField("servers", "servers", null, new ListOverlay<ServerImpl>("servers", this, ServerImpl.factory));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<PathImpl> paths = registerField("paths", "paths", "/.*",
-            new MapOverlay<PathImpl>("paths", this, PathImpl.factory, "/.*"));
+    private MapOverlay<PathImpl> paths = registerField("paths", "paths", "/.*", new MapOverlay<PathImpl>("paths", this, PathImpl.factory, "/.*"));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object, AnyObjectOverlay> pathsExtensions = registerField("paths", "pathsExtensions", "x-.*",
-            new ValMapOverlay<Object, AnyObjectOverlay>("paths", this, AnyObjectOverlay.factory, "x-.*"));
+    private ValMapOverlay<Object,AnyObjectOverlay> pathsExtensions = registerField("paths", "pathsExtensions", "x-.*", new ValMapOverlay<Object, AnyObjectOverlay>("paths", this, AnyObjectOverlay.factory, "x-.*"));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<SchemaImpl> schemas = registerField("components/schemas", "schemas", "[a-zA-Z0-9\\._-]+",
-            new MapOverlay<SchemaImpl>("components/schemas", this, SchemaImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<SchemaImpl> schemas = registerField("components/schemas", "schemas", "[a-zA-Z0-9\\._-]+", new MapOverlay<SchemaImpl>("components/schemas", this, SchemaImpl.factory, "[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<ResponseImpl> responses = registerField("components/responses", "responses", "[a-zA-Z0-9\\._-]+",
-            new MapOverlay<ResponseImpl>("components/responses", this, ResponseImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<ResponseImpl> responses = registerField("components/responses", "responses", "[a-zA-Z0-9\\._-]+", new MapOverlay<ResponseImpl>("components/responses", this, ResponseImpl.factory, "[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<ParameterImpl> parameters = registerField("components/parameters", "parameters",
-            "[a-zA-Z0-9\\._-]+",
-            new MapOverlay<ParameterImpl>("components/parameters", this, ParameterImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<ParameterImpl> parameters = registerField("components/parameters", "parameters", "[a-zA-Z0-9\\._-]+", new MapOverlay<ParameterImpl>("components/parameters", this, ParameterImpl.factory, "[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object, AnyObjectOverlay> examples = registerField("components/examples", "examples",
-            "[a-zA-Z0-9\\._-]+", new ValMapOverlay<Object, AnyObjectOverlay>("components/examples", this,
-                    AnyObjectOverlay.factory, "[a-zA-Z0-9\\._-]+"));
+    private ValMapOverlay<Object,AnyObjectOverlay> examples = registerField("components/examples", "examples", "[a-zA-Z0-9\\._-]+", new ValMapOverlay<Object, AnyObjectOverlay>("components/examples", this, AnyObjectOverlay.factory, "[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<RequestBodyImpl> requestBodies = registerField("components/requestBodies", "requestBodies",
-            "[a-zA-Z0-9\\._-]+", new MapOverlay<RequestBodyImpl>("components/requestBodies", this,
-                    RequestBodyImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<RequestBodyImpl> requestBodies = registerField("components/requestBodies", "requestBodies", "[a-zA-Z0-9\\._-]+", new MapOverlay<RequestBodyImpl>("components/requestBodies", this, RequestBodyImpl.factory, "[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<HeaderImpl> headers = registerField("components/headers", "headers", "[a-zA-Z0-9\\._-]+",
-            new MapOverlay<HeaderImpl>("components/headers", this, HeaderImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<HeaderImpl> headers = registerField("components/headers", "headers", "[a-zA-Z0-9\\._-]+", new MapOverlay<HeaderImpl>("components/headers", this, HeaderImpl.factory, "[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<SecuritySchemeImpl> securitySchemes = registerField("components/securitySchemes",
-            "securitySchemes", "[a-zA-Z0-9\\._-]+", new MapOverlay<SecuritySchemeImpl>("components/securitySchemes",
-                    this, SecuritySchemeImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<SecuritySchemeImpl> securitySchemes = registerField("components/securitySchemes", "securitySchemes", "[a-zA-Z0-9\\._-]+", new MapOverlay<SecuritySchemeImpl>("components/securitySchemes", this, SecuritySchemeImpl.factory, "[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<LinkImpl> links = registerField("components/links", "links", "[a-zA-Z0-9\\._-]+",
-            new MapOverlay<LinkImpl>("components/links", this, LinkImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<LinkImpl> links = registerField("components/links", "links", "[a-zA-Z0-9\\._-]+", new MapOverlay<LinkImpl>("components/links", this, LinkImpl.factory, "[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<CallbackImpl> callbacks = registerField("components/callbacks", "callbacks",
-            "(?!x-)[a-zA-Z0-9\\._-]+", new MapOverlay<CallbackImpl>("components/callbacks", this, CallbackImpl.factory,
-                    "(?!x-)[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<CallbackImpl> callbacks = registerField("components/callbacks", "callbacks", "(?!x-)[a-zA-Z0-9\\._-]+", new MapOverlay<CallbackImpl>("components/callbacks", this, CallbackImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object, AnyObjectOverlay> componentsExtensions = registerField("components",
-            "componentsExtensions", "x-.*",
-            new ValMapOverlay<Object, AnyObjectOverlay>("components", this, AnyObjectOverlay.factory, "x-.*"));
+    private ValMapOverlay<Object,AnyObjectOverlay> componentsExtensions = registerField("components", "componentsExtensions", "x-.*", new ValMapOverlay<Object, AnyObjectOverlay>("components", this, AnyObjectOverlay.factory, "x-.*"));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<SecurityRequirementImpl> securityRequirements = registerField("security", "securityRequirements",
-            null, new MapOverlay<SecurityRequirementImpl>("security", this, SecurityRequirementImpl.factory, null));
+    private MapOverlay<SecurityRequirementImpl> securityRequirements = registerField("security", "securityRequirements", null, new MapOverlay<SecurityRequirementImpl>("security", this, SecurityRequirementImpl.factory, null));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<TagImpl> tags = registerField("tags", "tags", null,
-            new MapOverlay<TagImpl>("tags", this, TagImpl.factory, null));
+    private MapOverlay<TagImpl> tags = registerField("tags", "tags", null, new MapOverlay<TagImpl>("tags", this, TagImpl.factory, null));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ExternalDocsImpl externalDocs = registerField("externalDocs", "externalDocs", null,
-            ExternalDocsImpl.factory.create("externalDocs", this));
+    private ExternalDocsImpl externalDocs = registerField("externalDocs", "externalDocs", null, ExternalDocsImpl.factory.create("externalDocs", this));
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object, AnyObjectOverlay> extensions = registerField("", "extensions", "x-.*",
-            new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.*"));
+    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.*", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.*"));
 
     // OpenApi
     @Override
@@ -196,8 +186,8 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setServers(Collection<? extends Server> servers) {
         @SuppressWarnings("unchecked")
-        Collection<ServerImpl> implServers = (Collection<ServerImpl>) servers;
-        this.servers.set(implServers);
+            Collection<ServerImpl> implServers = (Collection<ServerImpl>) servers;
+            this.servers.set(implServers);
     }
 
     @Override
@@ -241,8 +231,8 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setPaths(Map<String, ? extends Path> paths) {
         @SuppressWarnings("unchecked")
-        Map<String, PathImpl> implPaths = (Map<String, PathImpl>) paths;
-        this.paths.set(implPaths);
+            Map<String,PathImpl> implPaths = (Map<String, PathImpl>) paths;
+            this.paths.set(implPaths);
     }
 
     @Override
@@ -317,8 +307,8 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setSchemas(Map<String, ? extends Schema> schemas) {
         @SuppressWarnings("unchecked")
-        Map<String, SchemaImpl> implSchemas = (Map<String, SchemaImpl>) schemas;
-        this.schemas.set(implSchemas);
+            Map<String,SchemaImpl> implSchemas = (Map<String, SchemaImpl>) schemas;
+            this.schemas.set(implSchemas);
     }
 
     @Override
@@ -356,8 +346,8 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setResponses(Map<String, ? extends Response> responses) {
         @SuppressWarnings("unchecked")
-        Map<String, ResponseImpl> implResponses = (Map<String, ResponseImpl>) responses;
-        this.responses.set(implResponses);
+            Map<String,ResponseImpl> implResponses = (Map<String, ResponseImpl>) responses;
+            this.responses.set(implResponses);
     }
 
     @Override
@@ -395,8 +385,8 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setParameters(Map<String, ? extends Parameter> parameters) {
         @SuppressWarnings("unchecked")
-        Map<String, ParameterImpl> implParameters = (Map<String, ParameterImpl>) parameters;
-        this.parameters.set(implParameters);
+            Map<String,ParameterImpl> implParameters = (Map<String, ParameterImpl>) parameters;
+            this.parameters.set(implParameters);
     }
 
     @Override
@@ -471,8 +461,8 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setRequestBodies(Map<String, ? extends RequestBody> requestBodies) {
         @SuppressWarnings("unchecked")
-        Map<String, RequestBodyImpl> implRequestBodies = (Map<String, RequestBodyImpl>) requestBodies;
-        this.requestBodies.set(implRequestBodies);
+            Map<String,RequestBodyImpl> implRequestBodies = (Map<String, RequestBodyImpl>) requestBodies;
+            this.requestBodies.set(implRequestBodies);
     }
 
     @Override
@@ -510,8 +500,8 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setHeaders(Map<String, ? extends Header> headers) {
         @SuppressWarnings("unchecked")
-        Map<String, HeaderImpl> implHeaders = (Map<String, HeaderImpl>) headers;
-        this.headers.set(implHeaders);
+            Map<String,HeaderImpl> implHeaders = (Map<String, HeaderImpl>) headers;
+            this.headers.set(implHeaders);
     }
 
     @Override
@@ -549,8 +539,8 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setSecuritySchemes(Map<String, ? extends SecurityScheme> securitySchemes) {
         @SuppressWarnings("unchecked")
-        Map<String, SecuritySchemeImpl> implSecuritySchemes = (Map<String, SecuritySchemeImpl>) securitySchemes;
-        this.securitySchemes.set(implSecuritySchemes);
+            Map<String,SecuritySchemeImpl> implSecuritySchemes = (Map<String, SecuritySchemeImpl>) securitySchemes;
+            this.securitySchemes.set(implSecuritySchemes);
     }
 
     @Override
@@ -588,8 +578,8 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setLinks(Map<String, ? extends Link> links) {
         @SuppressWarnings("unchecked")
-        Map<String, LinkImpl> implLinks = (Map<String, LinkImpl>) links;
-        this.links.set(implLinks);
+            Map<String,LinkImpl> implLinks = (Map<String, LinkImpl>) links;
+            this.links.set(implLinks);
     }
 
     @Override
@@ -627,8 +617,8 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setCallbacks(Map<String, ? extends Callback> callbacks) {
         @SuppressWarnings("unchecked")
-        Map<String, CallbackImpl> implCallbacks = (Map<String, CallbackImpl>) callbacks;
-        this.callbacks.set(implCallbacks);
+            Map<String,CallbackImpl> implCallbacks = (Map<String, CallbackImpl>) callbacks;
+            this.callbacks.set(implCallbacks);
     }
 
     @Override
@@ -703,8 +693,8 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setSecurityRequirements(Map<String, ? extends SecurityRequirement> securityRequirements) {
         @SuppressWarnings("unchecked")
-        Map<String, SecurityRequirementImpl> implSecurityRequirements = (Map<String, SecurityRequirementImpl>) securityRequirements;
-        this.securityRequirements.set(implSecurityRequirements);
+            Map<String,SecurityRequirementImpl> implSecurityRequirements = (Map<String, SecurityRequirementImpl>) securityRequirements;
+            this.securityRequirements.set(implSecurityRequirements);
     }
 
     @Override
@@ -742,8 +732,8 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public void setTags(Map<String, ? extends Tag> tags) {
         @SuppressWarnings("unchecked")
-        Map<String, TagImpl> implTags = (Map<String, TagImpl>) tags;
-        this.tags.set(implTags);
+            Map<String,TagImpl> implTags = (Map<String, TagImpl>) tags;
+            this.tags.set(implTags);
     }
 
     @Override
@@ -810,10 +800,10 @@ public class Swagger3Impl extends SwaggerObjectImpl implements Swagger3 {
 
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     public static JsonOverlayFactory<Swagger3Impl> factory = new JsonOverlayFactory<Swagger3Impl>() {
-        @Override
-        public Swagger3Impl create(String key, JsonNode json, JsonOverlay<?> parent) {
-            return isEmptyRecursive(parent, Swagger3Impl.class) ? null : new Swagger3Impl(key, json, parent);
-        }
-    };
+    @Override
+    public Swagger3Impl create(String key, JsonNode json, JsonOverlay<?> parent) {
+        return isEmptyRecursive(parent, Swagger3Impl.class) ? null : new Swagger3Impl(key, json, parent);
+    }
+};
 
 }

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/coll/ListOverlay.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/coll/ListOverlay.java
@@ -34,6 +34,11 @@ public class ListOverlay<OV extends JsonOverlay<?>> extends JsonOverlay<Collecti
         reset();
     }
 
+    @Override
+    public boolean isMissing() {
+        return super.isMissing() || !getJson().isArray();
+    }
+
     private void reset() {
         super.set(store.getOverlays());
     }

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/coll/MapOverlay.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/coll/MapOverlay.java
@@ -41,6 +41,11 @@ public class MapOverlay<OV extends JsonOverlay<?>> extends JsonOverlay<Map<Strin
         reset();
     }
 
+    @Override
+    public boolean isMissing() {
+        return super.isMissing() || !getJson().isObject();
+    }
+
     private void reset() {
         super.set(store.getOverlayMap());
     }

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/coll/ObjectOverlay.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/coll/ObjectOverlay.java
@@ -28,6 +28,11 @@ public class ObjectOverlay<OO extends ObjectOverlay<OO>> extends JsonOverlay<OO>
     }
 
     @Override
+    public boolean isMissing() {
+        return super.isMissing() || !getJson().isObject();
+    }
+
+    @Override
     public JsonNode toJson() {
         return getJson(); // TODO fix this
     }

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/coll/ValListOverlay.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/coll/ValListOverlay.java
@@ -41,6 +41,11 @@ public class ValListOverlay<V, OV extends JsonOverlay<V>> extends JsonOverlay<Co
         reset();
     }
 
+    @Override
+    public boolean isMissing() {
+        return super.isMissing() || !getJson().isArray();
+    }
+
     private void reset() {
         values.clear();
         for (OV overlay : store.getOverlays()) {

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/coll/ValMapOverlay.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/coll/ValMapOverlay.java
@@ -45,6 +45,11 @@ public class ValMapOverlay<V, OV extends JsonOverlay<V>> extends JsonOverlay<Map
         super.set(getFromStore());
     }
 
+    @Override
+    public boolean isMissing() {
+        return super.isMissing() || !getJson().isObject();
+    }
+
     private Map<String, V> getFromStore() {
         values.clear();
         for (Entry<String, OV> entry : store.getOverlayMap().entrySet()) {

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/std/BooleanOverlay.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/std/BooleanOverlay.java
@@ -20,6 +20,11 @@ public class BooleanOverlay extends JsonOverlay<Boolean> {
     }
 
     @Override
+    public boolean isMissing() {
+        return super.isMissing() || !getJson().isBoolean();
+    }
+
+    @Override
     public Boolean fromJson() {
         JsonNode json = getJson();
         return json.isBoolean() ? json.booleanValue() : null;

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/std/IntegerOverlay.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/std/IntegerOverlay.java
@@ -20,6 +20,11 @@ public class IntegerOverlay extends JsonOverlay<Integer> {
     }
 
     @Override
+    public boolean isMissing() {
+        return super.isMissing() || !getJson().isIntegralNumber();
+    }
+
+    @Override
     public Integer fromJson() {
         JsonNode json = getJson();
         return json.isInt() ? json.intValue() : null;

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/std/NumberOverlay.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/std/NumberOverlay.java
@@ -24,6 +24,11 @@ public class NumberOverlay extends JsonOverlay<Number> {
     }
 
     @Override
+    public boolean isMissing() {
+        return super.isMissing() || !getJson().isNumber();
+    }
+
+    @Override
     public Number fromJson() {
         JsonNode json = getJson();
         if (json.isBigDecimal()) {

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/std/StringOverlay.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/jsonoverlay/std/StringOverlay.java
@@ -20,6 +20,11 @@ public class StringOverlay extends JsonOverlay<String> {
     }
 
     @Override
+    public boolean isMissing() {
+        return super.isMissing() || !getJson().isTextual();
+    }
+
+    @Override
     public String fromJson() {
         JsonNode json = getJson();
         return json.isTextual() ? json.textValue() : null;

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/model3/Header.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/model3/Header.java
@@ -1,5 +1,8 @@
 package com.reprezen.swaggerparser.model3;
 
+import com.reprezen.swaggerparser.model3.Parameter;
+import javax.annotation.Generated;
+
 public interface Header extends Parameter {
 
 }

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/model3/Schema.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/model3/Schema.java
@@ -252,6 +252,13 @@ public interface Schema extends SwaggerObject {
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     void removeProperty(String name);
 
+    // AdditionalPropertiesSchema
+    @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
+    Schema getAdditionalPropertiesSchema();
+
+    @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
+    void setAdditionalPropertiesSchema(Schema additionalPropertiesSchema);
+
     // AdditionalProperties
     @Generated("com.reprezen.swaggerparser.jsonoverlay.gen.CodeGenerator")
     Boolean getAdditionalProperties();

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/model3/Swagger3.java
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/model3/Swagger3.java
@@ -1,12 +1,25 @@
 package com.reprezen.swaggerparser.model3;
 
+import com.reprezen.swaggerparser.Swagger;
+import com.reprezen.swaggerparser.model3.Callback;
+import com.reprezen.swaggerparser.model3.ExternalDocs;
+import com.reprezen.swaggerparser.model3.Header;
+import com.reprezen.swaggerparser.model3.Info;
+import com.reprezen.swaggerparser.model3.Link;
+import com.reprezen.swaggerparser.model3.Parameter;
+import com.reprezen.swaggerparser.model3.Path;
+import com.reprezen.swaggerparser.model3.RequestBody;
+import com.reprezen.swaggerparser.model3.Response;
+import com.reprezen.swaggerparser.model3.Schema;
+import com.reprezen.swaggerparser.model3.SecurityRequirement;
+import com.reprezen.swaggerparser.model3.SecurityScheme;
+import com.reprezen.swaggerparser.model3.Server;
+import com.reprezen.swaggerparser.model3.SwaggerObject;
+import com.reprezen.swaggerparser.model3.Tag;
+import com.reprezen.swaggerparser.val.ValidationResults;
 import java.util.Collection;
 import java.util.Map;
-
 import javax.annotation.Generated;
-
-import com.reprezen.swaggerparser.Swagger;
-import com.reprezen.swaggerparser.val.ValidationResults;
 
 public interface Swagger3 extends SwaggerObject, Swagger {
 

--- a/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/types3.yaml
+++ b/reprezen-swagger-parser/src/main/java/com/reprezen/swaggerparser/types3.yaml
@@ -596,11 +596,13 @@ types:
         plural: Properties
         type: Schema
         structure: map
-      additionalProperties:
+      additionalPropertiesSchema:
         name: AdditionalPropertiesSchema
+        parentPath: additionalProperties
         type: Schema
-      additionalProperties:
+      additionalPropertiesBoolean:
         name: AdditionalProperties
+        parentPath: additionalProperties
         type: Boolean
       description:
         name: Description

--- a/reprezen-swagger-parser/src/test/resources/models/parseTest.yaml
+++ b/reprezen-swagger-parser/src/test/resources/models/parseTest.yaml
@@ -211,6 +211,7 @@ components:
           type: string
         c:
           type: string
+      additionalProperties: true
       description: description
       format: format
       default: xyzzy
@@ -237,6 +238,8 @@ components:
       x-foo: foo
     schema2:
       title: title
+      additionalProperties:
+        type: integer
   responses: 
     resp1:
       description: description


### PR DESCRIPTION
Implementation is based on JsonOverlay#isMissing method, which was
modified throughout the JsonOverlay framework classes so that objects
bound to JSON of the incorrect type now show up as missing (which they
logically are). This may not work properly under mutator API (see issue
3), but it should be reliable for pure parse-only scenarios for now.